### PR TITLE
adds benib/aurelia-leaflet plugin

### DIFF
--- a/plugin-registry.json
+++ b/plugin-registry.json
@@ -31,6 +31,11 @@
       "location": "ceoaliongroo/aurelia-leaflet"
     },
     {
+      "name": "leaflet",
+      "endpoint": "github",
+      "location": "benib/aurelia-leaflet"
+    },
+    {
       "name": "materialize",
       "endpoint": "github",
       "location": "manuel-guilbault/aurelia-materialize"


### PR DESCRIPTION
This adds my take on a aurelia-leaflet plugin to the registry.
Not sure if it is an issue that there is already another plugin with the same name in the registry.
When I checked last, other aurelia-leaflet plugins were more or less just a skeleton-plugin fork. I've seen that the one in the registry here matured a bit when I checked again after I released my aurelia-leaflet plugin, but it is still lacking a lot of features.

https://github.com/benib/aurelia-leaflet is in an early stage but is already usable and has a project page with documentation and some examples over here: http://benib.github.io/aurelia-leaflet/
