### PR TITLE
rename aurelia-notification to aurelia-notify because of naming conflicts

### DIFF
--- a/plugin-registry.json
+++ b/plugin-registry.json
@@ -96,9 +96,9 @@
       "location": "aurelia-ui-toolkits/aurelia-materialize-bridge"
     },
     {
-      "name": "notification",
+      "name": "notify",
       "endpoint": "github",
-      "location": "MarcScheib/aurelia-notification"
+      "location": "MarcScheib/aurelia-notify"
     },
     {
       "name": "rethink-bindtable",


### PR DESCRIPTION
Naming conflicts in the JSPM registry caused me to rename the plugin/repository
